### PR TITLE
Adding support for automatically reloading the list files of dnsbl-lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ _see more examples in test.js_
 }
 ```
 
+### Reload list files on change:
+
+#####  lookup.setReloadListsOnChange(do_reload_lists_on_change)
+Sets wheter dnsbl-lookup should automatically reload the list files in the list folder when they're changed.
+
+ * `do_reload_lists_on_change`: boolean
+
 ### Command-line:
 
 ```bash     


### PR DESCRIPTION
I'd like this feature very much for my current project, I only require dnsbl-lookup once and the sysadmin would like to edit the JSON files without having to reboot the whole node process.